### PR TITLE
change InboxForActor => InboxesForIRI

### DIFF
--- a/pub/database.go
+++ b/pub/database.go
@@ -59,13 +59,23 @@ type Database interface {
 	//
 	// The library makes this call only after acquiring a lock first.
 	OutboxForInbox(c context.Context, inboxIRI *url.URL) (outboxIRI *url.URL, err error)
-	// InboxForActor fetches the inbox corresponding to the given actorIRI.
+	// InboxesForIRI fetches inboxes corresponding to the given iri.
+	// This allows your server to skip remote dereferencing of iris
+	// in order to speed up message delivery, if desired.
 	//
-	// It is acceptable to just return nil for the inboxIRI. In this case, the library will
-	// attempt to resolve the inbox of the actor by remote dereferencing instead.
+	// It is acceptable to just return nil or an empty slice for the inboxIRIs,
+	// if you don't know the inbox iri, or you don't wish to use this feature.
+	// In this case, the library will attempt to resolve inboxes of the iri
+	// by remote dereferencing instead.
+	//
+	// If the input iri is the iri of an Actor, then the inbox for the actor
+	// should be returned as a single-entry slice.
+	//
+	// If the input iri is a Collection (such as a Collection of followers),
+	// then each follower inbox IRI should be returned in the inboxIRIs slice.
 	//
 	// The library makes this call only after acquiring a lock first.
-	InboxForActor(c context.Context, actorIRI *url.URL) (inboxIRI *url.URL, err error)
+	InboxesForIRI(c context.Context, iri *url.URL) (inboxIRIs []*url.URL, err error)
 	// Exists returns true if the database has an entry for the specified
 	// id. It may not be owned by this application instance.
 	//

--- a/pub/mock_database_test.go
+++ b/pub/mock_database_test.go
@@ -199,19 +199,19 @@ func (mr *MockDatabaseMockRecorder) InboxContains(c, inbox, id interface{}) *gom
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InboxContains", reflect.TypeOf((*MockDatabase)(nil).InboxContains), c, inbox, id)
 }
 
-// InboxForActor mocks base method.
-func (m *MockDatabase) InboxForActor(c context.Context, actorIRI *url.URL) (*url.URL, error) {
+// InboxesForIRI mocks base method.
+func (m *MockDatabase) InboxesForIRI(c context.Context, iri *url.URL) ([]*url.URL, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "InboxForActor", c, actorIRI)
-	ret0, _ := ret[0].(*url.URL)
+	ret := m.ctrl.Call(m, "InboxesForIRI", c, iri)
+	ret0, _ := ret[0].([]*url.URL)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// InboxForActor indicates an expected call of InboxForActor.
-func (mr *MockDatabaseMockRecorder) InboxForActor(c, actorIRI interface{}) *gomock.Call {
+// InboxesForIRI indicates an expected call of InboxesForIRI.
+func (mr *MockDatabaseMockRecorder) InboxesForIRI(c, iri interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InboxForActor", reflect.TypeOf((*MockDatabase)(nil).InboxForActor), c, actorIRI)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InboxesForIRI", reflect.TypeOf((*MockDatabase)(nil).InboxesForIRI), c, iri)
 }
 
 // Liked mocks base method.


### PR DESCRIPTION
This PR changes the InboxForActor function to InboxesForIRI, which allows more than one IRI to be returned.

This is useful in cases where the input IRI (formerly actor IRI) is in fact a Collection, like a collection of followers.