### PR TITLE
[feature] updates Dereference() function signature to return entire http.Response{} for more flexible usage

### DIFF
--- a/pub/base_actor.go
+++ b/pub/base_actor.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 
@@ -195,12 +194,8 @@ func (b *baseActor) PostInboxScheme(c context.Context, w http.ResponseWriter, r 
 	// Begin processing the request, but have not yet applied
 	// authorization (ex: blocks). Obtain the activity reject unknown
 	// activities.
-	raw, err := ioutil.ReadAll(r.Body)
+	m, err := readActivityPubReq(r)
 	if err != nil {
-		return true, err
-	}
-	var m map[string]interface{}
-	if err = json.Unmarshal(raw, &m); err != nil {
 		return true, err
 	}
 	asValue, err := streams.ToType(c, m)
@@ -340,12 +335,8 @@ func (b *baseActor) PostOutboxScheme(c context.Context, w http.ResponseWriter, r
 		return true, nil
 	}
 	// Everything is good to begin processing the request.
-	raw, err := ioutil.ReadAll(r.Body)
+	m, err := readActivityPubReq(r)
 	if err != nil {
-		return true, err
-	}
-	var m map[string]interface{}
-	if err = json.Unmarshal(raw, &m); err != nil {
 		return true, err
 	}
 	// Note that converting to a Type will NOT successfully convert types

--- a/pub/base_actor.go
+++ b/pub/base_actor.go
@@ -67,12 +67,7 @@ func NewSocialActor(c CommonBehavior,
 	clock Clock) Actor {
 	return &baseActor{
 		// Use SideEffectActor without s2s.
-		delegate: &SideEffectActor{
-			common: c,
-			c2s:    c2s,
-			db:     db,
-			clock:  clock,
-		},
+		delegate:             NewSideEffectActor(c, nil, c2s, db, clock),
 		enableSocialProtocol: true,
 		clock:                clock,
 	}
@@ -97,12 +92,7 @@ func NewFederatingActor(c CommonBehavior,
 	return &baseActorFederating{
 		baseActor{
 			// Use SideEffectActor without c2s.
-			delegate: &SideEffectActor{
-				common: c,
-				s2s:    s2s,
-				db:     db,
-				clock:  clock,
-			},
+			delegate:                NewSideEffectActor(c, s2s, nil, db, clock),
 			enableFederatedProtocol: true,
 			clock:                   clock,
 		},

--- a/pub/federating_wrapped_callbacks.go
+++ b/pub/federating_wrapped_callbacks.go
@@ -2,7 +2,6 @@ package pub
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/url"
 
@@ -244,12 +243,12 @@ func (w FederatingWrappedCallbacks) create(c context.Context, a vocab.ActivitySt
 			if err != nil {
 				return err
 			}
-			b, err := tport.Dereference(c, iter.GetIRI())
+			resp, err := tport.Dereference(c, iter.GetIRI())
 			if err != nil {
 				return err
 			}
-			var m map[string]interface{}
-			if err = json.Unmarshal(b, &m); err != nil {
+			m, err := readActivityPubResp(resp)
+			if err != nil {
 				return err
 			}
 			t, err = streams.ToType(c, m)
@@ -514,12 +513,12 @@ func (w FederatingWrappedCallbacks) accept(c context.Context, a vocab.ActivitySt
 				if err != nil {
 					return err
 				}
-				b, err := tport.Dereference(c, iter.GetIRI())
+				resp, err := tport.Dereference(c, iter.GetIRI())
 				if err != nil {
 					return err
 				}
-				var m map[string]interface{}
-				if err = json.Unmarshal(b, &m); err != nil {
+				m, err := readActivityPubResp(resp)
+				if err != nil {
 					return err
 				}
 				t, err = streams.ToType(c, m)

--- a/pub/federating_wrapped_callbacks_test.go
+++ b/pub/federating_wrapped_callbacks_test.go
@@ -298,7 +298,7 @@ func TestFederatedCreate(t *testing.T) {
 		mockDB.EXPECT().Lock(ctx, mustParse(testNoteId1)).Return(func() {}, nil)
 		mockDB.EXPECT().Create(ctx, toDeserializedForm(testFederatedNote))
 		mockTp.EXPECT().Dereference(ctx, mustParse(testNoteId1)).Return(
-			mustSerializeToBytes(testFederatedNote), nil)
+			mustWrapInGETResponse(mustParse(testNoteId1), testFederatedNote), nil)
 		c := newCreateFn()
 		op := streams.NewActivityStreamsObjectProperty()
 		op.AppendIRI(mustParse(testNoteId1))
@@ -754,7 +754,7 @@ func TestFederatedAccept(t *testing.T) {
 		mockDB.EXPECT().ActorForInbox(ctx, mustParse(testMyInboxIRI)).Return(
 			mustParse(testFederatedActorIRI2), nil)
 		mockTp.EXPECT().Dereference(ctx, mustParse(testFederatedActivityIRI)).Return(
-			mustSerializeToBytes(testFollow), nil)
+			mustWrapInGETResponse(mustParse(testFederatedActivityIRI), testFollow), nil)
 		mockDB.EXPECT().Lock(ctx, mustParse(testFederatedActivityIRI)).Return(func() {}, nil)
 		mockDB.EXPECT().Get(ctx, mustParse(testFederatedActivityIRI)).Return(
 			testFollow, nil)
@@ -1650,7 +1650,7 @@ func TestFederatedUndo(t *testing.T) {
 		defer ctl.Finish()
 		w, mockTp := setupFn(ctl)
 		mockTp.EXPECT().Dereference(ctx, mustParse(testFederatedActivityIRI)).Return(
-			mustSerializeToBytes(testListen), nil)
+			mustWrapInGETResponse(mustParse(testFederatedActivityIRI), testListen), nil)
 		u := newUndoFn()
 		actor := streams.NewActivityStreamsActorProperty()
 		actor.AppendIRI(mustParse(testFederatedActorIRI2))
@@ -1665,7 +1665,7 @@ func TestFederatedUndo(t *testing.T) {
 		defer ctl.Finish()
 		w, mockTp := setupFn(ctl)
 		mockTp.EXPECT().Dereference(ctx, mustParse(testFederatedActivityIRI)).Return(
-			mustSerializeToBytes(testFollow), nil)
+			mustWrapInGETResponse(mustParse(testFederatedActivityIRI), testFollow), nil)
 		u := newUndoFn()
 		op := streams.NewActivityStreamsObjectProperty()
 		op.AppendIRI(mustParse(testFederatedActivityIRI))
@@ -1680,7 +1680,7 @@ func TestFederatedUndo(t *testing.T) {
 		defer ctl.Finish()
 		w, mockTp := setupFn(ctl)
 		mockTp.EXPECT().Dereference(ctx, mustParse(testFederatedActivityIRI)).Return(
-			mustSerializeToBytes(testListen), nil)
+			mustWrapInGETResponse(mustParse(testFederatedActivityIRI), testListen), nil)
 		u := newUndoFn()
 		err := w.undo(ctx, u)
 		if err != nil {
@@ -1692,7 +1692,7 @@ func TestFederatedUndo(t *testing.T) {
 		defer ctl.Finish()
 		w, mockTp := setupFn(ctl)
 		mockTp.EXPECT().Dereference(ctx, mustParse(testFederatedActivityIRI)).Return(
-			mustSerializeToBytes(testListen), nil)
+			mustWrapInGETResponse(mustParse(testFederatedActivityIRI), testListen), nil)
 		u := newUndoFn()
 		op := streams.NewActivityStreamsObjectProperty()
 		op.AppendIRI(mustParse(testFederatedActivityIRI))
@@ -1707,7 +1707,7 @@ func TestFederatedUndo(t *testing.T) {
 		defer ctl.Finish()
 		w, mockTp := setupFn(ctl)
 		mockTp.EXPECT().Dereference(ctx, mustParse(testFederatedActivityIRI)).Return(
-			mustSerializeToBytes(testListen), nil)
+			mustWrapInGETResponse(mustParse(testFederatedActivityIRI), testListen), nil)
 		var gotc context.Context
 		var got vocab.ActivityStreamsUndo
 		w.Undo = func(ctx context.Context, v vocab.ActivityStreamsUndo) error {

--- a/pub/mock_transport_test.go
+++ b/pub/mock_transport_test.go
@@ -6,65 +6,37 @@ package pub
 
 import (
 	context "context"
-	gomock "github.com/golang/mock/gomock"
 	http "net/http"
 	url "net/url"
 	reflect "reflect"
+
+	gomock "github.com/golang/mock/gomock"
 )
 
-// MockTransport is a mock of Transport interface
+// MockTransport is a mock of Transport interface.
 type MockTransport struct {
 	ctrl     *gomock.Controller
 	recorder *MockTransportMockRecorder
 }
 
-// MockTransportMockRecorder is the mock recorder for MockTransport
+// MockTransportMockRecorder is the mock recorder for MockTransport.
 type MockTransportMockRecorder struct {
 	mock *MockTransport
 }
 
-// NewMockTransport creates a new mock instance
+// NewMockTransport creates a new mock instance.
 func NewMockTransport(ctrl *gomock.Controller) *MockTransport {
 	mock := &MockTransport{ctrl: ctrl}
 	mock.recorder = &MockTransportMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockTransport) EXPECT() *MockTransportMockRecorder {
 	return m.recorder
 }
 
-// Dereference mocks base method
-func (m *MockTransport) Dereference(c context.Context, iri *url.URL) ([]byte, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Dereference", c, iri)
-	ret0, _ := ret[0].([]byte)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// Dereference indicates an expected call of Dereference
-func (mr *MockTransportMockRecorder) Dereference(c, iri interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Dereference", reflect.TypeOf((*MockTransport)(nil).Dereference), c, iri)
-}
-
-// Deliver mocks base method
-func (m *MockTransport) Deliver(c context.Context, b []byte, to *url.URL) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Deliver", c, b, to)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// Deliver indicates an expected call of Deliver
-func (mr *MockTransportMockRecorder) Deliver(c, b, to interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Deliver", reflect.TypeOf((*MockTransport)(nil).Deliver), c, b, to)
-}
-
-// BatchDeliver mocks base method
+// BatchDeliver mocks base method.
 func (m *MockTransport) BatchDeliver(c context.Context, b []byte, recipients []*url.URL) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "BatchDeliver", c, b, recipients)
@@ -72,36 +44,65 @@ func (m *MockTransport) BatchDeliver(c context.Context, b []byte, recipients []*
 	return ret0
 }
 
-// BatchDeliver indicates an expected call of BatchDeliver
+// BatchDeliver indicates an expected call of BatchDeliver.
 func (mr *MockTransportMockRecorder) BatchDeliver(c, b, recipients interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BatchDeliver", reflect.TypeOf((*MockTransport)(nil).BatchDeliver), c, b, recipients)
 }
 
-// MockHttpClient is a mock of HttpClient interface
+// Deliver mocks base method.
+func (m *MockTransport) Deliver(c context.Context, b []byte, to *url.URL) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Deliver", c, b, to)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Deliver indicates an expected call of Deliver.
+func (mr *MockTransportMockRecorder) Deliver(c, b, to interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Deliver", reflect.TypeOf((*MockTransport)(nil).Deliver), c, b, to)
+}
+
+// Dereference mocks base method.
+func (m *MockTransport) Dereference(c context.Context, iri *url.URL) (*http.Response, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Dereference", c, iri)
+	ret0, _ := ret[0].(*http.Response)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Dereference indicates an expected call of Dereference.
+func (mr *MockTransportMockRecorder) Dereference(c, iri interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Dereference", reflect.TypeOf((*MockTransport)(nil).Dereference), c, iri)
+}
+
+// MockHttpClient is a mock of HttpClient interface.
 type MockHttpClient struct {
 	ctrl     *gomock.Controller
 	recorder *MockHttpClientMockRecorder
 }
 
-// MockHttpClientMockRecorder is the mock recorder for MockHttpClient
+// MockHttpClientMockRecorder is the mock recorder for MockHttpClient.
 type MockHttpClientMockRecorder struct {
 	mock *MockHttpClient
 }
 
-// NewMockHttpClient creates a new mock instance
+// NewMockHttpClient creates a new mock instance.
 func NewMockHttpClient(ctrl *gomock.Controller) *MockHttpClient {
 	mock := &MockHttpClient{ctrl: ctrl}
 	mock.recorder = &MockHttpClientMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockHttpClient) EXPECT() *MockHttpClientMockRecorder {
 	return m.recorder
 }
 
-// Do mocks base method
+// Do mocks base method.
 func (m *MockHttpClient) Do(req *http.Request) (*http.Response, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Do", req)
@@ -110,7 +111,7 @@ func (m *MockHttpClient) Do(req *http.Request) (*http.Response, error) {
 	return ret0, ret1
 }
 
-// Do indicates an expected call of Do
+// Do indicates an expected call of Do.
 func (mr *MockHttpClientMockRecorder) Do(req interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Do", reflect.TypeOf((*MockHttpClient)(nil).Do), req)

--- a/pub/pub_test.go
+++ b/pub/pub_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -468,6 +469,21 @@ func wrappedInCreate(t vocab.Type) vocab.ActivityStreamsCreate {
 	op.AppendType(t)
 	create.SetActivityStreamsObject(op)
 	return create
+}
+
+// mustWrapInGETResponse wraps a vocab.Type as serialized JSON response body to GET request with IRI.
+func mustWrapInGETResponse(iri *url.URL, t vocab.Type) *http.Response {
+	r := new(http.Response)
+	r.Request = new(http.Request)
+	r.Request.Method = http.MethodGet
+	r.Request.URL = iri
+	r.Status = http.StatusText(http.StatusOK)
+	r.StatusCode = http.StatusOK
+	body := bytes.NewReader(mustSerializeToBytes(t))
+	r.Body = io.NopCloser(body)
+	r.Header = make(http.Header)
+	r.Header.Set("Content-Type", activityStreamsMediaTypes[0])
+	return r
 }
 
 // mustSerializeToBytes serializes a type to bytes or panics.

--- a/pub/side_effect_actor.go
+++ b/pub/side_effect_actor.go
@@ -629,14 +629,14 @@ func (a *SideEffectActor) hasInboxForwardingValues(c context.Context, inboxIRI *
 		if err != nil {
 			return false, err
 		}
-		b, err := tport.Dereference(c, iri)
+		resp, err := tport.Dereference(c, iri)
 		if err != nil {
 			// Do not fail the entire process if the data is
 			// missing.
 			continue
 		}
-		var m map[string]interface{}
-		if err = json.Unmarshal(b, &m); err != nil {
+		m, err := readActivityPubResp(resp)
+		if err != nil {
 			return false, err
 		}
 		t, err := streams.ToType(c, m)
@@ -855,13 +855,14 @@ func (a *SideEffectActor) resolveActors(c context.Context, t Transport, r []*url
 // The returned actor could be nil, if it wasn't an actor (ex: a Collection or
 // OrderedCollection).
 func (a *SideEffectActor) dereferenceForResolvingInboxes(c context.Context, t Transport, actorIRI *url.URL) (actor vocab.Type, moreActorIRIs []*url.URL, err error) {
-	var resp []byte
+	var resp *http.Response
 	resp, err = t.Dereference(c, actorIRI)
 	if err != nil {
 		return
 	}
 	var m map[string]interface{}
-	if err = json.Unmarshal(resp, &m); err != nil {
+	m, err = readActivityPubResp(resp)
+	if err != nil {
 		return
 	}
 	actor, err = streams.ToType(c, m)

--- a/pub/side_effect_actor_test.go
+++ b/pub/side_effect_actor_test.go
@@ -25,13 +25,7 @@ func TestPassThroughMethods(t *testing.T) {
 		sp = NewMockSocialProtocol(ctl)
 		db = NewMockDatabase(ctl)
 		cl = NewMockClock(ctl)
-		a = &SideEffectActor{
-			common: c,
-			s2s:    fp,
-			c2s:    sp,
-			db:     db,
-			clock:  cl,
-		}
+		a = NewSideEffectActor(c, fp, sp, db, cl)
 		return
 	}
 	// Run tests
@@ -127,13 +121,7 @@ func TestAuthorizePostInbox(t *testing.T) {
 		sp = NewMockSocialProtocol(ctl)
 		db = NewMockDatabase(ctl)
 		cl = NewMockClock(ctl)
-		a = &SideEffectActor{
-			common: c,
-			s2s:    fp,
-			c2s:    sp,
-			db:     db,
-			clock:  cl,
-		}
+		a = NewSideEffectActor(c, fp, sp, db, cl)
 		return
 	}
 	// Run tests
@@ -198,13 +186,7 @@ func TestPostInbox(t *testing.T) {
 		sp = NewMockSocialProtocol(ctl)
 		db = NewMockDatabase(ctl)
 		cl = NewMockClock(ctl)
-		a = &SideEffectActor{
-			common: c,
-			s2s:    fp,
-			c2s:    sp,
-			db:     db,
-			clock:  cl,
-		}
+		a = NewSideEffectActor(c, fp, sp, db, cl)
 		return
 	}
 	// Run tests
@@ -350,13 +332,7 @@ func TestInboxForwarding(t *testing.T) {
 		sp = NewMockSocialProtocol(ctl)
 		db = NewMockDatabase(ctl)
 		cl = NewMockClock(ctl)
-		a = &SideEffectActor{
-			common: c,
-			s2s:    fp,
-			c2s:    sp,
-			db:     db,
-			clock:  cl,
-		}
+		a = NewSideEffectActor(c, fp, sp, db, cl)
 		return
 	}
 	t.Run("DoesNotForwardIfAlreadyExists", func(t *testing.T) {
@@ -762,13 +738,7 @@ func TestPostOutbox(t *testing.T) {
 		sp = NewMockSocialProtocol(ctl)
 		db = NewMockDatabase(ctl)
 		cl = NewMockClock(ctl)
-		a = &SideEffectActor{
-			common: c,
-			s2s:    fp,
-			c2s:    sp,
-			db:     db,
-			clock:  cl,
-		}
+		a = NewSideEffectActor(c, fp, sp, db, cl)
 		return
 	}
 	t.Run("AddsToEmptyOutbox", func(t *testing.T) {
@@ -910,13 +880,7 @@ func TestAddNewIDs(t *testing.T) {
 		sp = NewMockSocialProtocol(ctl)
 		db = NewMockDatabase(ctl)
 		cl = NewMockClock(ctl)
-		a = &SideEffectActor{
-			common: c,
-			s2s:    fp,
-			c2s:    sp,
-			db:     db,
-			clock:  cl,
-		}
+		a = NewSideEffectActor(c, fp, sp, db, cl)
 		return
 	}
 	t.Run("AddsIdToActivityWithoutId", func(t *testing.T) {
@@ -1009,13 +973,7 @@ func TestDeliver(t *testing.T) {
 		sp = NewMockSocialProtocol(ctl)
 		db = NewMockDatabase(ctl)
 		cl = NewMockClock(ctl)
-		a = &SideEffectActor{
-			common: c,
-			s2s:    fp,
-			c2s:    sp,
-			db:     db,
-			clock:  cl,
-		}
+		a = NewSideEffectActor(c, fp, sp, db, cl)
 		return
 	}
 	t.Run("SendToRecipientsInTo", func(t *testing.T) {
@@ -1567,13 +1525,7 @@ func TestWrapInCreate(t *testing.T) {
 		sp = NewMockSocialProtocol(ctl)
 		db = NewMockDatabase(ctl)
 		cl = NewMockClock(ctl)
-		a = &SideEffectActor{
-			common: c,
-			s2s:    fp,
-			c2s:    sp,
-			db:     db,
-			clock:  cl,
-		}
+		a = NewSideEffectActor(c, fp, sp, db, cl)
 		return
 	}
 	t.Run("CreateHasObjectAndActor", func(t *testing.T) {

--- a/pub/side_effect_actor_test.go
+++ b/pub/side_effect_actor_test.go
@@ -535,9 +535,11 @@ func TestInboxForwarding(t *testing.T) {
 			db.EXPECT().Lock(ctx, mustParse(testNoteId1)).Return(func() {}, nil),
 			db.EXPECT().Owns(ctx, mustParse(testNoteId1)).Return(false, nil),
 			cm.EXPECT().NewTransport(ctx, mustParse(testMyInboxIRI), goFedUserAgent()).Return(mockTPortTag, nil),
-			mockTPortTag.EXPECT().Dereference(ctx, mustParse(testTagIRI)).Return(mustSerializeToBytes(newObjectWithId(testTagIRI)), nil),
+			mockTPortTag.EXPECT().Dereference(ctx, mustParse(testTagIRI)).Return(
+				mustWrapInGETResponse(mustParse(testTagIRI), newObjectWithId(testTagIRI)), nil),
 			cm.EXPECT().NewTransport(ctx, mustParse(testMyInboxIRI), goFedUserAgent()).Return(mockTPortTag2, nil),
-			mockTPortTag2.EXPECT().Dereference(ctx, mustParse(testTagIRI2)).Return(mustSerializeToBytes(newObjectWithId(testTagIRI2)), nil),
+			mockTPortTag2.EXPECT().Dereference(ctx, mustParse(testTagIRI2)).Return(
+				mustWrapInGETResponse(mustParse(testTagIRI2), newObjectWithId(testTagIRI2)), nil),
 		)
 		// Run
 		err := a.InboxForwarding(ctx, mustParse(testMyInboxIRI), input)

--- a/pub/util.go
+++ b/pub/util.go
@@ -74,32 +74,54 @@ const (
 
 // readActivityPubReq reads ActivityPub data from an incoming request, handling body close.
 func readActivityPubReq(req *http.Request) (map[string]interface{}, error) {
+	// Ensure closed when done.
 	defer req.Body.Close()
+
 	var m map[string]interface{}
+
+	// Wrap body in a JSON decoder.
 	dec := json.NewDecoder(req.Body)
+
+	// Decode JSON body as "raw" AP data map.
 	if err := dec.Decode(&m); err != nil {
 		return nil, err
 	}
+
+	// Perform a final second decode to ensure no trailing
+	// garbage data or second JSON value (indicates malformed).
 	if err := dec.Decode(&struct{}{}); err != io.EOF {
 		return nil, errors.New("trailing data after json")
 	}
+
 	return m, nil
 }
 
 // readActivityPubResp reads ActivityPub data from a dereference response, handling media type check and body close.
 func readActivityPubResp(resp *http.Response) (map[string]interface{}, error) {
+	// Ensure closed when done.
 	defer resp.Body.Close()
+
+	// Check the incoming response media type is the expected ActivityPub content-type.
 	if mediaType := resp.Header.Get("Content-Type"); !headerIsActivityPubMediaType(mediaType) {
 		return nil, fmt.Errorf("%s %s resp was not ActivityPub media type: %s", resp.Request.Method, resp.Request.URL, mediaType)
 	}
+
 	var m map[string]interface{}
+
+	// Wrap body in a JSON decoder.
 	dec := json.NewDecoder(resp.Body)
+
+	// Decode JSON body as "raw" AP data map.
 	if err := dec.Decode(&m); err != nil {
 		return nil, err
 	}
+
+	// Perform a final second decode to ensure no trailing
+	// garbage data or second JSON value (indicates malformed).
 	if err := dec.Decode(&struct{}{}); err != io.EOF {
 		return nil, errors.New("trailing data after json")
 	}
+
 	return m, nil
 }
 

--- a/pub/util.go
+++ b/pub/util.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"net/url"
 	"strings"
@@ -70,6 +71,37 @@ const (
 	// The Accept header.
 	acceptHeader = "Accept"
 )
+
+// readActivityPubReq reads ActivityPub data from an incoming request, handling body close.
+func readActivityPubReq(req *http.Request) (map[string]interface{}, error) {
+	defer req.Body.Close()
+	var m map[string]interface{}
+	dec := json.NewDecoder(req.Body)
+	if err := dec.Decode(&m); err != nil {
+		return nil, err
+	}
+	if err := dec.Decode(&struct{}{}); err != io.EOF {
+		return nil, errors.New("trailing data after json")
+	}
+	return m, nil
+}
+
+// readActivityPubResp reads ActivityPub data from a dereference response, handling media type check and body close.
+func readActivityPubResp(resp *http.Response) (map[string]interface{}, error) {
+	defer resp.Body.Close()
+	if mediaType := resp.Header.Get("Content-Type"); !headerIsActivityPubMediaType(mediaType) {
+		return nil, fmt.Errorf("%s %s resp was not ActivityPub media type: %s", resp.Request.Method, resp.Request.URL, mediaType)
+	}
+	var m map[string]interface{}
+	dec := json.NewDecoder(resp.Body)
+	if err := dec.Decode(&m); err != nil {
+		return nil, err
+	}
+	if err := dec.Decode(&struct{}{}); err != io.EOF {
+		return nil, errors.New("trailing data after json")
+	}
+	return m, nil
+}
 
 // isActivityPubPost returns true if the request is a POST request that has the
 // ActivityStreams content type header
@@ -774,12 +806,12 @@ func mustHaveActivityActorsMatchObjectActors(c context.Context,
 		if err != nil {
 			return err
 		}
-		b, err := tport.Dereference(c, iri)
+		resp, err := tport.Dereference(c, iri)
 		if err != nil {
 			return err
 		}
-		var m map[string]interface{}
-		if err = json.Unmarshal(b, &m); err != nil {
+		m, err := readActivityPubResp(resp)
+		if err != nil {
 			return err
 		}
 		t, err := streams.ToType(c, m)


### PR DESCRIPTION
As it says in the above title. This also includes updating relevant code using the dereferencer, updating relevant tests, and adds checks on dereferenced ActivityPub media types (which should fix [CVE-2024-25623](https://nvd.nist.gov/vuln/detail/CVE-2024-25623) for anyone using this library and relying on in-built federating wrapped callbacks and the like).

Note the `activity/pub` tests are currently failing due to the following panic:
```
--- FAIL: TestInboxForwarding (0.00s)
    --- PASS: TestInboxForwarding/DoesNotForwardIfAlreadyExists (0.00s)
    --- PASS: TestInboxForwarding/DoesNotForwardIfToCollectionNotOwned (0.00s)
    --- PASS: TestInboxForwarding/DoesNotForwardIfCcCollectionNotOwned (0.00s)
    --- PASS: TestInboxForwarding/DoesNotForwardIfAudienceCollectionNotOwned (0.00s)
    --- PASS: TestInboxForwarding/DoesNotForwardIfToOwnedButNotCollection (0.00s)
    --- PASS: TestInboxForwarding/DoesNotForwardIfCcOwnedButNotCollection (0.00s)
    --- PASS: TestInboxForwarding/DoesNotForwardIfAudienceOwnedButNotCollection (0.00s)
    --- PASS: TestInboxForwarding/DoesNotForwardIfNoChainIsOwned (0.00s)
    --- FAIL: TestInboxForwarding/ForwardsToRecipients (0.00s)
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
        panic: runtime error: invalid memory address or nil pointer dereference [recovered]
        panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0xbfb819]

goroutine 72 [running]:
testing.tRunner.func1.2({0xce4020, 0x15a49d0})
        /usr/lib/go/src/testing/testing.go:1631 +0x24a
testing.tRunner.func1()
        /usr/lib/go/src/testing/testing.go:1634 +0x377
panic({0xce4020?, 0x15a49d0?})
        /usr/lib/go/src/runtime/panic.go:770 +0x132
github.com/golang/mock/gomock.(*Controller).finish(0xc0004b6cc0, 0x0, {0xce4020, 0x15a49d0})
        /home/kim/Projects/main/activity/vendor/github.com/golang/mock/gomock/controller.go:288 +0x40b
github.com/golang/mock/gomock.(*Controller).Finish(0xc0004b6cc0)
        /home/kim/Projects/main/activity/vendor/github.com/golang/mock/gomock/controller.go:269 +0x37
panic({0xce4020?, 0x15a49d0?})
        /usr/lib/go/src/runtime/panic.go:770 +0x132
github.com/superseriousbusiness/activity/pub.(*SideEffectActor).deliverToRecipients(0xc000586780, {0x1038c88, 0x1638000}, 0xc0006035f0, {0x7ff3a2bcbc90?, 0xc00058adc8?}, {0xc00046dd30, 0x2, 0x2})
        /home/kim/Projects/main/activity/pub/side_effect_actor.go:475 +0x79
github.com/superseriousbusiness/activity/pub.(*SideEffectActor).InboxForwarding(0xc000586780, {0x1038c88, 0x1638000}, 0xc0006035f0, {0x7ff3a2bcbc90, 0xc00058adc8})
        /home/kim/Projects/main/activity/pub/side_effect_actor.go:360 +0x10e5
github.com/superseriousbusiness/activity/pub.TestInboxForwarding.func10(0xc00036e000)
        /home/kim/Projects/main/activity/pub/side_effect_actor_test.go:599 +0x11b9
testing.tRunner(0xc00036e000, 0xc00014f1a0)
        /usr/lib/go/src/testing/testing.go:1689 +0xfb
created by testing.(*T).Run in goroutine 204
        /usr/lib/go/src/testing/testing.go:1742 +0x390
FAIL    github.com/superseriousbusiness/activity/pub    0.026s
FAIL
```

I *think* this panic is unrelated to the changes I have made, but if it is a result of them I'll fix it. At the moment I'm a little puzzled by it. (it seems to be due to a nil side effect actor serialize function in the tests)